### PR TITLE
Fixed issue with integer conversion of OTP

### DIFF
--- a/api/user_verification.py
+++ b/api/user_verification.py
@@ -20,7 +20,7 @@ class UserVerification:
                             "first_name": members.get(_id).get("first_name"),
                             "last_name": members.get(_id).get("last_name"),
                             "umass_email": self.requestJSON["umass_email"],                            
-                            "otp": self.requestJSON["otp"],
+                            "otp": str(self.requestJSON["otp"]).zfill(4),
                         },
                     }
                 else:


### PR DESCRIPTION
This PR is intended to fix #1. 

### Changelog
-  Added `zfill` on the string version of the erroneous integer OTP to have 4 digits