### PR TITLE
Added 'email' in expected fields for Lab Suggestions

### DIFF
--- a/api/lab_ideas.py
+++ b/api/lab_ideas.py
@@ -9,6 +9,7 @@ class LabIdeas:
         self.expectedFields = [
             "first_name",
             "last_name",
+            "email",
             "idea_text",
             "ip_address"
         ]


### PR DESCRIPTION
This PR is intended to fix issue with missing email in database for lab suggestions